### PR TITLE
Hide filters when $showFilters is false

### DIFF
--- a/resources/views/tailwind/includes/filters.blade.php
+++ b/resources/views/tailwind/includes/filters.blade.php
@@ -1,4 +1,4 @@
-@if ($filtersView || count($customFilters))
+@if ($showFilters && ($filtersView || count($customFilters)))
     <div
         x-data="{ open: false }"
         @keydown.escape.stop="open = false"


### PR DESCRIPTION
The existing $showFilters option was only partially hiding filters (i.e. leaving the filters dropdown showing). This patch fixed that on the tailwind theme.